### PR TITLE
when using --keydir, whitelist only files ending in .pub

### DIFF
--- a/lib/key.js
+++ b/lib/key.js
@@ -59,8 +59,12 @@ exports.addKeysFromDirectory = function(ip, dir, progress_cb, cb) {
     if (progress_cb) progress_cb("reading public keys from " + dir);
     var keys = [];
     files.forEach(function(f) {
-      // skip tilde files
-      if (f.substr(-1) === '~') return;
+      // Whitelist: keys must end in .pub
+      if (f.substr('-4') !== '.pub') {
+        console.log("keydir: Skipping", f, "because it does not end in '.pub'");
+        return;
+      }
+
       var content = fs.readFileSync(path.join(dir, f));
       content = content.toString().split("\n");
       content.forEach(function(k) {


### PR DESCRIPTION
so for example you could just say `--keydir /path/to/identity-pubkeys` and not get other files
