### PR TITLE
Add -g option to use custom security group name

### DIFF
--- a/awsbox.js
+++ b/awsbox.js
@@ -181,6 +181,7 @@ verbs['create'] = function(args) {
     })
     .describe('t', 'Instance type, dictates VM speed and cost.  i.e. t1.micro or m1.large (see http://aws.amazon.com/ec2/instance-types/)')
     .default('t', 't1.micro')
+    .describe('g', 'security group name, finds or creates a security group with this name')
     .describe('p', 'public SSL key (installed automatically when provided)')
     .describe('s', 'secret SSL key (installed automatically when provided)')
     .check(function(argv) {
@@ -245,7 +246,8 @@ verbs['create'] = function(args) {
     }
 
     vm.startImage({
-      type: opts.t
+      type: opts.t,
+      groupName: opts.g
     }, function(err, r) {
       checkErr(err);
       console.log("   ... VM launched, waiting for startup (should take about 20s)");

--- a/lib/sec.js
+++ b/lib/sec.js
@@ -13,8 +13,8 @@ function createError(msg, r) {
   return msg;
 }
 
-exports.getName = function(cb) {
-  var groupName = "awsbox group v" + SECURITY_GROUP_VERSION;
+exports.getName = function(name, cb) {
+  var groupName = name || "awsbox group v" + SECURITY_GROUP_VERSION;
 
   // is this fingerprint known?
   aws.client.call('DescribeSecurityGroups', {

--- a/lib/vm.js
+++ b/lib/vm.js
@@ -182,7 +182,7 @@ function returnSingleImageInfo(result, cb) {
 exports.startImage = function(opts, cb) {
   key.getName(function(err, keyName) {
     if (err) return cb(err);
-    sec.getName(function(err, groupName) {
+    sec.getName(opts.groupName, function(err, groupName) {
       if (err) return cb(err);
       aws.client.call('RunInstances', {
         ImageId: TEMPLATE_IMAGE_ID,


### PR DESCRIPTION
After the instance is created, you can't change security groups, so something like this is needed if you don't want your awsboxen to all share the same security group.

This approach assumes the developer will manage the security group settings through some other means (web ui or java api tools).

I have another patch stashed away that takes the security group from the config file and lets the developer pass through the settings when creating the group, let me know if you'd rather go that route.
