### PR TITLE
replace undefined checkErr function

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -4,7 +4,8 @@ exports.get = function() {
   try {
     var awsboxJson = JSON.parse(fs.readFileSync("./.awsbox.json"));
   } catch(e) {
-    checkErr("Can't read awsbox.json: " + e);
+    process.stderr.write('ERRORE FATALE: ' + e + "\n");
+    process.exit(1);
   }
 
   return awsboxJson;


### PR DESCRIPTION
So you don't get:

```
reading .awsbox.json
fatal error: error running 'create' command: ReferenceError: checkErr is not defined
```

Seems easier just to inline the function code than to make a separate utils module to import checkErr from.
