### PR TITLE
Fix error codes that are sent to callbacks on git errors

### DIFF
--- a/lib/git.js
+++ b/lib/git.js
@@ -103,7 +103,7 @@ exports.push = function(dir, host, pr, cb) {
   p.stdout.on('data', function(c) { splitAndEmit(c, pr); });
   p.stderr.on('data', function(c) { splitAndEmit(c, pr); });
   p.on('exit', function(code, signal) {
-    return cb(code = 0);
+    return cb(code != 0);
   });
 };
 
@@ -121,7 +121,7 @@ exports.pull = function(dir, remote, branch, pr, cb) {
   p.stderr.on('data', function(c) { splitAndEmit(c, pr); });
 
   p.on('exit', function(code, signal) {
-    return cb(code = 0);
+    return cb(code != 0);
   });
 }
 
@@ -133,6 +133,6 @@ exports.init = function(dir, cb) {
     })
   });
   p.on('exit', function(code, signal) {
-    return cb(code = 0);
+    return cb(code != 0);
   });
 };


### PR DESCRIPTION
When the gitc library functions are called, if they error out, they currently always call the callback with a value of 0 which means we can't detect if errors actually happened or not. This fixes it so we get a true or false value to the callback.
