### PR TITLE
Added clearer error when missing env vars for aws credentials.

### DIFF
--- a/awsbox.js
+++ b/awsbox.js
@@ -547,6 +547,9 @@ aws.setRegion(process.env['AWS_REGION'], function(err, region) {
   try {
     if (err) throw err;
     if (region) console.log("(Using region", region.region + ")");
+    if (!process.env['AWS_ID'] || !process.env['AWS_KEY']) {
+      fail('Missing aws credentials\nPlease configure the AWS_ID and AWS_KEY environment variables.');
+    }
     verbs[verb](process.argv.slice(3));
   } catch(e) {
     fail("error running '".error + verb + "' command: ".error + e);


### PR DESCRIPTION
Before this change the error looks like.

```
$ node awsbox.js zones
fatal error: error running 'zones' command: secretAccessKey and accessKeyId must be set
```

After change.

```
fatal error: Missing aws credentials
Please configure the AWS_ID and AWS_KEY environment variables.
```

Makes it a little clearer to the user what they need to correct :smile: and does it before entering any other code.

Cheers
