### PR TITLE
Add optional "ami" property to .awsbox.json

### DIFF
--- a/awsbox.js
+++ b/awsbox.js
@@ -154,7 +154,7 @@ verbs['findbyip'] = function(args) {
     console.log(err, fqdns);
   });
 };
-verbs['findbyip'].doc = "find a hostname given an ip address (via zerigo, requires ZERIGO_DNS_KEY)"; 
+verbs['findbyip'].doc = "find a hostname given an ip address (via zerigo, requires ZERIGO_DNS_KEY)";
 
 verbs['zones'] = function(args) {
   aws.zones(function(err, r) {
@@ -259,6 +259,7 @@ verbs['create'] = function(args) {
     }
 
     vm.startImage({
+      ami: awsboxJson.ami,
       type: opts.t,
       groupName: opts.g
     }, function(err, r) {

--- a/doc/JSON.md
+++ b/doc/JSON.md
@@ -9,7 +9,7 @@ This file documents the supported keys.
 
 ### `.processes` (**required**)
 
-An array of processes that should be started upon git push.  The first process in 
+An array of processes that should be started upon git push.  The first process in
 the list will be public (external requests routed to it), others will be
 "private".  Only the first entry in the list will have a `PORT` env var defined
 at the time of execution and it must bind this port on localhost.
@@ -61,7 +61,7 @@ Available hooks include:
 Run as the `app` user after every git push, after npm install of modules.
 
 #### `poststart`
- 
+
 Run as the `app` user after every git push, after your server processes are
 started.
 
@@ -75,7 +75,7 @@ The local_hooks key allows you to specify scripts that will run on
 the client at various points during deployment.
 
 #### `poststart`
- 
+
 Run locally as the current user after every git push.
 
 #### `postcreate`
@@ -93,4 +93,18 @@ example:
       "packages": [
         "mysql-server"
       ]
+    }
+
+### `.ami` (*optional*)
+
+Use a custom AWS AMI base image. This defaults to "ami-8af096e3", a basic
+Linux AMI with node 0.8.17 and all the magic that makes awsbox easy. It is
+recommended to base new AMIs from the default and use `awsbox createami` for
+customization.
+
+example:
+
+    {
+      "ami": "ami-6f690106",
+      "processes": [ "myscript.js" ]
     }

--- a/lib/vm.js
+++ b/lib/vm.js
@@ -185,7 +185,7 @@ exports.startImage = function(opts, cb) {
     sec.getName(opts.groupName, function(err, groupName) {
       if (err) return cb(err);
       aws.client.call('RunInstances', {
-        ImageId: TEMPLATE_IMAGE_ID,
+        ImageId: opts.ami || TEMPLATE_IMAGE_ID,
         KeyName: keyName,
         SecurityGroup: groupName,
         InstanceType: opts.type,


### PR DESCRIPTION
Allows you to specify a custom AMI base image. With no "ami" set `awsbox create` will use the default AMI (ami-8af096e3)
### Example:

``` json
{
  "ami": "ami-6f690106",
  "processes": [
    "helloworld.js"
  ]
}
```
