### PR TITLE
Use child_process.spawn instead of exec for remote script calls

### DIFF
--- a/lib/ssh.js
+++ b/lib/ssh.js
@@ -76,9 +76,17 @@ exports.updatePackages = function(host, cb) {
 exports.runScript = function(host, script, cb) {
   if (!script) return cb(null);
   var cmd = 'ssh -o "StrictHostKeyChecking no" ec2-user@' + host + " < " + script;
-  var cp = child_process.exec(cmd, function(err, r) {
-    cb(err);
-  });
+  var args = ['sh', '-c', cmd];
+  var cp = child_process.spawn(args[0], args.slice(1),{env: process.env});
+
+  cp.on('close', function (code) {
+      if (0 != code) {
+          cb("Spawn process '" + cmd + "' exited with return code " + code);
+      } else {
+          cb();
+      }
+  })
+
   passthrough(cp);
 };
 


### PR DESCRIPTION
Resolves issue #69.
