### PR TITLE
Add in the reaper.js and new awsbox.js related functionality

### DIFF
--- a/awsbox.js
+++ b/awsbox.js
@@ -20,10 +20,12 @@ fs = require('fs'),
 relativeDate = require('relative-date'),
 existsSync = fs.existsSync || path.existsSync; // existsSync moved path to fs in 0.7.x
 
-// allow multiple different env vars
-[ 'AWS_KEY', 'AWS_SECRET_KEY', 'AWS_ACCESS_KEY' ].forEach(function(x) {
+// allow multiple different env vars, AWS_ACCESS_KEY, AWS_SECRET_KEY 
+// are used by the EC2 CLI
+[ 'AWS_KEY', 'AWS_SECRET_KEY' ].forEach(function(x) {
   process.env['AWS_SECRET'] = process.env['AWS_SECRET'] || process.env[x];
 });
+process.env['AWS_ID'] = process.env['AWS_ID'] || process.env['AWS_ACCESS_KEY'];
 
 colors.setTheme({
   input: 'grey',

--- a/awsbox.js
+++ b/awsbox.js
@@ -11,7 +11,6 @@ const
 aws = require('./lib/aws.js'),
 path = require('path'),
 vm = require('./lib/vm.js'),
-reaper = require('./lib/reaper.js'),
 key = require('./lib/key.js'),
 ssh = require('./lib/ssh.js'),
 dns = require('./lib/dns.js'),
@@ -179,79 +178,6 @@ verbs['zones'] = function(args) {
 };
 verbs['zones'].doc = "list amazon availability zones";
 
-verbs['reap'] = function(args) {
-  var parser = optimist(args)
-    .usage('awsbox reap: reap VMs that have been running for too long')
-    .describe('dryrun', 'Perform a dry run')
-    .boolean('dryrun')
-    .default('dryrun', true)
-    .describe('warn1', 'num. hours old for first warning')
-    .default('warn1', 5 * 24)
-    .describe('warn2', 'num. hours after 1st warning to send final warning')
-    .default('warn2', 24)
-    .describe('terminate', 'num. hours after 2nd warning to terminate the box')
-    .default('terminate', 24);
-
-  vm.listawsboxes(function(err, results) {
-    Object.keys(results).forEach(function(instanceName) {
-      var i = results[instanceName], 
-          instanceId = i.instanceId;
-
-      if (typeof(i.tags['AWSBOX_NOKILL']) != 'undefined') {
-        console.log("NO_KILL " + instanceId);
-        return
-      }
-
-      // for testing w/ only once instance
-      if (instanceId != "i-ca512eb3") {
-        return;
-      }
-
-      var AWSBOX_OWNER = (typeof(i.tags['AWSBOX_OWNER']) == 'undefined') ?
-        '' : i.tags['AWSBOX_OWNER'];
-
-      var AWSBOX_REAP = reaper.getState(i);
-
-      if (AWSBOX_REAP.state === 0) { // never seen before...
-        console.log("Setting initial reaper state: ", instanceId);
-        reaper.setState(instanceId, 1, function(err) {
-            if (err) {
-              console.error('ERROR Setting AWSBOX_REAP initial state');
-              return;
-            }
-        });
-      } else if (AWSBOX_REAP.state === 1 && AWSBOX_REAP.deltaHours > parser.argv.warn1) {
-        console.log("sending warning 1");
-        reaper.setState(instanceId, 2, function(err) {
-            if (err) {
-              console.error('ERROR Setting first warning state');
-              return;
-            }
-        });
-      } else if (AWSBOX_REAP.state === 2 && AWSBOX_REAP.deltaHours > parser.argv.warn2) {
-        console.log("sending warning 2");
-        reaper.setState(instanceId, 3, function(err) {
-            if (err) {
-              console.error('ERROR Setting second warning state');
-              return;
-            }
-        });
-      } else if (AWSBOX_REAP.state === 3 && AWSBOX_REAP.deltaHours > parser.argv.terminate) {
-        if (typeof(i.tags['AWSBOX_SPAREME']) !== 'undefined') {
-          vm.deleteTags(instanceId, ['AWSBOX_SPAREME', 'AWSBOX_REAP'], function(err) {
-            if (err) {
-              console.error('ERROR Setting second warning state');
-              return;
-            }
-          });
-        } else {
-          console.log("Deleting instance: ", instanceId);
-        }
-      }
-
-    });
-  });
-};
 
 verbs['create'] = function(args) {
   var parser = optimist(args)

--- a/awsbox.js
+++ b/awsbox.js
@@ -416,6 +416,21 @@ verbs['list'] = function(args) {
 };
 verbs['list'].doc = "\tlist all VMs on the aws account";
 
+verbs['list-awsboxes'] = function(args) {
+  vm.listawsboxes(function(err, r) {
+    checkErr(err);
+    Object.keys(r).forEach(function(k) {
+      var v = r[k];
+      var dispName = v.name;
+      if (dispName.indexOf(v.instanceId) === -1) dispName += " {" + v.instanceId + "}";
+      console.log(util.format('  %s:\t\n    %s, %s, launched %s\n',
+                              dispName, v.ipAddress, v.instanceType,
+                              relativeDate(v.launchTime)));
+    });
+  });
+};
+verbs['list-awsboxes'].doc = 'list all AWSBOX instances on the aws account'
+
 verbs['update'] = function(args) {
   if (!args || args.length != 1) {
     throw 'missing required argument: name of instance'.error;

--- a/awsbox.js
+++ b/awsbox.js
@@ -561,6 +561,35 @@ verbs['removekey'] = function(args) {
 };
 verbs['removekey'].doc = "remove a specific ssh key from an instance";
 
+
+/* reaper specific keys */
+verbs['spare'] = function(args) {
+  if (args.length != 1) {
+    throw 'Args required for spare: instance_id'.error;
+  }
+
+  var instanceId = args[0];
+  vm.setTag(instanceId, 'AWSBOX_SPAREME', '1', function(err) {
+    if (err) {
+      console.error("ERROR: ", err);
+    }
+  });
+};
+verbs['spare'].doc = 'spare the box from the reaper for another week'
+verbs['nokill'] = function(args) {
+  if (args.length != 1) {
+    throw 'Args required for nokill: instance_id'.error;
+  }
+
+  var instanceId = args[0];
+  vm.setTag(instanceId, 'AWSBOX_NOKILL', '1', function(err) {
+    if (err) {
+      console.error("ERROR: ", err);
+    }
+  });
+};
+verbs['nokill'].doc = 'prevent the reaper from terminating this box'
+
 if (process.argv.length <= 2) fail();
 
 var verb = process.argv[2].toLowerCase();

--- a/awsbox.js
+++ b/awsbox.js
@@ -2,6 +2,11 @@
 
 process.title = 'awsbox';
 
+// allow support for multiple sources for the ID / Secret
+// AWS_ACCESS_KEY and AWS_SECRET_KEY are used by the EC2 CLI tools so these are preferred
+process.env['AWS_ID'] = process.env['AWS_ID'] || process.env['AWS_ACCESS_KEY'];
+process.env['AWS_SECRET'] = process.env['AWS_SECRET'] || process.env['AWS_KEY'] || process.env['AWS_SECRET_KEY']
+
 const
 aws = require('./lib/aws.js'),
 path = require('path'),
@@ -19,13 +24,6 @@ util = require('util'),
 fs = require('fs'),
 relativeDate = require('relative-date'),
 existsSync = fs.existsSync || path.existsSync; // existsSync moved path to fs in 0.7.x
-
-// allow multiple different env vars, AWS_ACCESS_KEY, AWS_SECRET_KEY 
-// are used by the EC2 CLI
-[ 'AWS_KEY', 'AWS_SECRET_KEY' ].forEach(function(x) {
-  process.env['AWS_SECRET'] = process.env['AWS_SECRET'] || process.env[x];
-});
-process.env['AWS_ID'] = process.env['AWS_ID'] || process.env['AWS_ACCESS_KEY'];
 
 colors.setTheme({
   input: 'grey',

--- a/lib/reaper.js
+++ b/lib/reaper.js
@@ -1,0 +1,36 @@
+const
+aws = require('./aws.js'),
+vm  = require('./vm.js');
+
+exports.setState = function(id, state, cb) {
+  var state = "" + state + "|" + (Math.floor(Date.now()/1000));
+  vm.setTag(id, 'AWSBOX_REAP', state, cb);
+};
+
+exports.getState = function(instanceData) {
+
+  try {
+    var parts = instanceData.tags['AWSBOX_REAP'].split('|');
+
+    if (parts.length !== 2) {
+      throw new Error('well return the default');
+    }
+
+    var state = parseInt(parts[0], 10),
+        last  = parseInt(parts[1], 10),
+        deltaHours = Math.floor( (Date.now()/1000 - last) / 3600); // in hours
+
+    return {
+      state: state, 
+      last: last,
+      deltaHours: deltaHours
+    };
+
+  } catch(e) {
+    return {
+      state: 0, 
+      last: 0,
+      deltaHours: 0
+    };
+  }
+};

--- a/lib/vm.js
+++ b/lib/vm.js
@@ -57,6 +57,25 @@ exports.list = function(cb) {
   });
 };
 
+exports.listawsboxes = function(cb) {
+  aws.client.call('DescribeInstances', {}, function(result) {
+    var instances = {};
+    var i = 1;
+    jsel.forEach(
+      '.instancesSet > .item:has(.instanceState .name:val("running"))',
+      result, function(item) {
+        var isAWSBOX = jsel.match('.tagSet :has(.key:val("AWSBOX")) > .value', item).length != 0 
+        if (isAWSBOX == false) return;
+
+        var deets = extractInstanceDeets(item);
+        var key = deets.name || item.instanceId;
+        if (instances[key]) key += " {" + item.instanceId + "}";
+        instances[key] = deets;
+      });
+    cb(null, instances);
+  });
+};
+
 // given something the user typed in, try to figure out what instance they're talking about
 function findInstance(r, name) {
   if (typeof name !== 'string') name = name.toString();

--- a/lib/vm.js
+++ b/lib/vm.js
@@ -28,6 +28,14 @@ function extractInstanceDeets(horribleBlob) {
     instance.name = instance.instanceId;
   }
 
+  // extract the tags
+  instance.tags = {}
+  if (horribleBlob.tagSet && horribleBlob.tagSet.item.length > 0) {
+    horribleBlob.tagSet.item.forEach(function(tagDef) {
+      instance.tags[tagDef.key] = tagDef.value
+    });
+  }
+
   return instance;
 }
 
@@ -58,21 +66,20 @@ exports.list = function(cb) {
 };
 
 exports.listawsboxes = function(cb) {
-  aws.client.call('DescribeInstances', {}, function(result) {
-    var instances = {};
-    var i = 1;
-    jsel.forEach(
-      '.instancesSet > .item:has(.instanceState .name:val("running"))',
-      result, function(item) {
-        var isAWSBOX = jsel.match('.tagSet :has(.key:val("AWSBOX")) > .value', item).length != 0 
-        if (isAWSBOX == false) return;
+  exports.list(function(err, instances) {
+    if (err) {
+      return cb(err, null);
+    }
 
-        var deets = extractInstanceDeets(item);
-        var key = deets.name || item.instanceId;
-        if (instances[key]) key += " {" + item.instanceId + "}";
-        instances[key] = deets;
-      });
-    cb(null, instances);
+    // extract everything tagged w/ AWSBOX
+    var filtered = {};
+    Object.keys(instances).forEach(function(k) {
+      if (instances[k].tags['AWSBOX']) {
+        filtered[k] = instances[k]
+      }
+    });
+
+    cb(null, filtered);
   });
 };
 

--- a/lib/vm.js
+++ b/lib/vm.js
@@ -252,14 +252,39 @@ exports.waitForInstance = function(id, cb) {
   });
 };
 
-exports.setName = function(id, name, cb) {
+// http://docs.aws.amazon.com/AWSEC2/latest/APIReference/ApiReference-query-DeleteTags.html
+exports.deleteTags = function(id, key, cb) {
+  if (! key instanceof Array) {
+    key = [ key ];
+  }
+
+  var delObj = {
+    "ResourceId.0" : id,
+  };
+
+  for(var i=0; i < key.length; i++) {
+    delObj['Tag.'+i+'.Key'] = key[i];
+  }
+
+  aws.client.call('DeleteTags', delObj, function(result) {
+    if (result && result.return === 'true') return cb(null);
+    try { return cb(result.Errors.Error.Message); } catch(e) {};
+    return cb('unknown error deleting instance tag');
+  });
+};
+
+exports.setTag = function(id, key, value, cb) {
   aws.client.call('CreateTags', {
     "ResourceId.0": id,
-    "Tag.0.Key": 'Name',
-    "Tag.0.Value": name
+    "Tag.0.Key": key,
+    "Tag.0.Value": value
   }, function(result) {
     if (result && result.return === 'true') return cb(null);
     try { return cb(result.Errors.Error.Message); } catch(e) {};
-    return cb('unknown error setting instance name');
+    return cb('unknown error setting instance tag');
   });
+};
+
+exports.setName = function(id, name, cb) {
+  exports.setTag(id, 'Name', name, cb);
 };

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "optimist": "0.3.1",
     "urlparse": "0.0.1",
     "relative-date": "1.1.1",
-    "colors": "~0.6.0-1"
+    "colors": "~0.6.0-1",
+    "nodemailer": "0.5.0"
   },
   "devDependencies": {},
   "scripts": {},

--- a/reaper-templates/terminated.txt
+++ b/reaper-templates/terminated.txt
@@ -1,11 +1,11 @@
 Hello, 
 
-This is the AWSBOX Reaper. This is to let you know that your AWSBOX:
+This is the AWSBOX Reaper. 
+
+This is to let you know that your AWSBOX has been terminated:
 
   ==INSTANCE_NAME==
 
-has been terminated.
 
 Have a nice day. 
-
 AWSBOX Reaper.

--- a/reaper-templates/terminated.txt
+++ b/reaper-templates/terminated.txt
@@ -1,0 +1,11 @@
+Hello, 
+
+This is the AWSBOX Reaper. This is to let you know that your AWSBOX:
+
+  ==INSTANCE_NAME==
+
+has been terminated.
+
+Have a nice day. 
+
+AWSBOX Reaper.

--- a/reaper-templates/warning1.txt
+++ b/reaper-templates/warning1.txt
@@ -1,0 +1,23 @@
+Hello, 
+
+This is the AWSBOX Reaper. This is your first warning that your AWSBOX: 
+
+  ==INSTANCE_NAME==
+
+is going to be terminated. 
+
+If you would like to extend the life of your AWSBOX please run this command: 
+
+  > awsbox spare ==INSTANCE_ID==
+
+and I will let it live for a little while longer. 
+
+If this AWSBOX should NEVER be shutdown please run this command: 
+
+  > awsbox NOKILL ==INSTANCE_ID==
+
+If you do not need it anymore please ignore this warning. 
+
+Thank you. 
+
+AWSBOX Reaper.

--- a/reaper-templates/warning1.txt
+++ b/reaper-templates/warning1.txt
@@ -16,7 +16,7 @@ To add an extra week to your AWSBOX use this command:
 
 To have me ignore the box forever use this command:
 
-    > awsbox NOKILL ==INSTANCE_ID==
+    > awsbox nokill ==INSTANCE_ID==
 
 
 If you do not need it anymore please ignore this warning and 

--- a/reaper-templates/warning1.txt
+++ b/reaper-templates/warning1.txt
@@ -1,26 +1,26 @@
 Hello, 
 
-This is the AWSBOX Reaper. This is your first warning that your AWSBOX: 
+I am the AWSBOX Reaper. 
 
-  ==INSTANCE_NAME==
+This is your first warning that your AWSBOX: 
 
-is going to be terminated. 
+    ==INSTANCE_NAME== 
 
-If you would like to extend the life of your AWSBOX please run this command: 
-
-  > awsbox spare ==INSTANCE_ID==
-
-and I will let it live for a little while longer. 
+will be terminated in 48 hours.
 
 
-If this AWSBOX should NEVER be shutdown please run this command: 
+To add an extra week to your AWSBOX use this command: 
 
-  > awsbox NOKILL ==INSTANCE_ID==
+    > awsbox spare ==INSTANCE_ID==
 
-and I will ignore it forever.
 
-If you do not need it anymore please ignore this warning. 
+To have me ignore the box forever use this command:
+
+    > awsbox NOKILL ==INSTANCE_ID==
+
+
+If you do not need it anymore please ignore this warning and 
+I'll take care of it. 
 
 Thank you. 
-
 AWSBOX Reaper.

--- a/reaper-templates/warning1.txt
+++ b/reaper-templates/warning1.txt
@@ -12,9 +12,12 @@ If you would like to extend the life of your AWSBOX please run this command:
 
 and I will let it live for a little while longer. 
 
+
 If this AWSBOX should NEVER be shutdown please run this command: 
 
   > awsbox NOKILL ==INSTANCE_ID==
+
+and I will ignore it forever.
 
 If you do not need it anymore please ignore this warning. 
 

--- a/reaper-templates/warning2.txt
+++ b/reaper-templates/warning2.txt
@@ -1,0 +1,26 @@
+Hello, 
+
+This is the AWSBOX Reaper. This is your *FINAL* warning that your AWSBOX: 
+
+  ==INSTANCE_NAME==
+
+is going to be terminated. 
+
+If you would like to extend the life of your AWSBOX please run this command: 
+
+  > awsbox spare ==INSTANCE_ID==
+
+and I will let it live for a little while longer. 
+
+
+If this AWSBOX should NEVER be shutdown please run this command: 
+
+  > awsbox NOKILL ==INSTANCE_ID==
+
+and I will ignore it forever.
+
+If you do not need it anymore please ignore this warning. 
+
+Thank you. 
+
+AWSBOX Reaper.

--- a/reaper-templates/warning2.txt
+++ b/reaper-templates/warning2.txt
@@ -16,7 +16,7 @@ To add an extra week to your AWSBOX use this command:
 
 To have me ignore the box forever use this command:
 
-    > awsbox NOKILL ==INSTANCE_ID==
+    > awsbox nokill ==INSTANCE_ID==
 
 
 If you do not need it anymore please ignore this warning and 

--- a/reaper-templates/warning2.txt
+++ b/reaper-templates/warning2.txt
@@ -1,26 +1,26 @@
 Hello, 
 
-This is the AWSBOX Reaper. This is your *FINAL* warning that your AWSBOX: 
+I am the AWSBOX Reaper. 
 
-  ==INSTANCE_NAME==
+This is your FINAL warning that your AWSBOX: 
 
-is going to be terminated. 
+    ==INSTANCE_NAME== 
 
-If you would like to extend the life of your AWSBOX please run this command: 
-
-  > awsbox spare ==INSTANCE_ID==
-
-and I will let it live for a little while longer. 
+will be terminated in 24 hours!
 
 
-If this AWSBOX should NEVER be shutdown please run this command: 
+To add an extra week to your AWSBOX use this command: 
 
-  > awsbox NOKILL ==INSTANCE_ID==
+    > awsbox spare ==INSTANCE_ID==
 
-and I will ignore it forever.
 
-If you do not need it anymore please ignore this warning. 
+To have me ignore the box forever use this command:
+
+    > awsbox NOKILL ==INSTANCE_ID==
+
+
+If you do not need it anymore please ignore this warning and 
+I'll take care of it. 
 
 Thank you. 
-
 AWSBOX Reaper.

--- a/reaper.js
+++ b/reaper.js
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+process.title = 'awsbox';
+
+// allow support for multiple sources for the ID / Secret
+// AWS_ACCESS_KEY and AWS_SECRET_KEY are used by the EC2 CLI tools so these are preferred
+process.env['AWS_ID'] = process.env['AWS_ID'] || process.env['AWS_ACCESS_KEY'];
+process.env['AWS_SECRET'] = process.env['AWS_SECRET'] || process.env['AWS_KEY'] || process.env['AWS_SECRET_KEY']
+
+const 
+aws = require('./lib/aws.js'),
+path = require('path'),
+vm = require('./lib/vm.js'),
+reaper = require('./lib/reaper.js'),
+mailer = require('nodemailer').createTransport('SMTP', { host: 'localhost' }),  // TODO improve
+optimist = require('optimist');
+
+var parser = optimist(args)
+  .usage('awsbox reap: reap VMs that have been running for too long')
+  .describe('dryrun', 'Perform a dry run')
+  .boolean('dryrun')
+  .default('dryrun', true)
+  .describe('warn1', 'num. hours old for first warning')
+  .default('warn1', 5 * 24)
+  .describe('warn2', 'num. hours after 1st warning to send final warning')
+  .default('warn2', 24)
+  .describe('terminate', 'num. hours after 2nd warning to terminate the box')
+  .default('terminate', 24);
+
+vm.listawsboxes(function(err, results) {
+  Object.keys(results).forEach(function(instanceName) {
+    var i = results[instanceName], 
+        instanceId = i.instanceId, 
+        name = (typeof(i.tags['Name']) !== undefined ** i.tags['name'] !== '') ? i.tags['name'] : 'un-named';
+    ;
+
+    if (typeof(i.tags['AWSBOX_NOKILL']) != 'undefined') {
+      console.log("NO_KILL " + instanceId);
+      return
+    }
+
+    // for testing w/ only once instance
+    if (instanceId != "i-ca512eb3") {
+      return;
+    }
+
+    var AWSBOX_OWNER = (typeof(i.tags['AWSBOX_OWNER']) == 'undefined') ?
+      '' : i.tags['AWSBOX_OWNER'];
+
+    var AWSBOX_REAP = reaper.getState(i);
+
+    if (AWSBOX_REAP.state === 0) { // never seen before...
+      console.log("Setting initial reaper state: ", instanceId, name);
+      reaper.setState(instanceId, 1, function(err) {
+          if (err) {
+            console.error('ERROR Setting AWSBOX_REAP initial state');
+            return;
+          }
+      });
+    } else if (AWSBOX_REAP.state === 1 && AWSBOX_REAP.deltaHours > parser.argv.warn1) {
+      console.log("Sending warning 1", instanceId, name);
+
+      reaper.setState(instanceId, 2, function(err) {
+          if (err) {
+            console.error('ERROR Setting first warning state');
+            return;
+          }
+      });
+    } else if (AWSBOX_REAP.state === 2 && AWSBOX_REAP.deltaHours > parser.argv.warn2) {
+      console.log("sending warning 2");
+      reaper.setState(instanceId, 3, function(err) {
+          if (err) {
+            console.error('ERROR Setting second warning state');
+            return;
+          }
+      });
+    } else if (AWSBOX_REAP.state === 3 && AWSBOX_REAP.deltaHours > parser.argv.terminate) {
+      if (typeof(i.tags['AWSBOX_SPAREME']) !== 'undefined') {
+        vm.deleteTags(instanceId, ['AWSBOX_SPAREME', 'AWSBOX_REAP'], function(err) {
+          if (err) {
+            console.error('ERROR Setting second warning state');
+            return;
+          }
+        });
+      } else {
+        console.log("Deleting instance: ", instanceId);
+      }
+    }
+  });
+});

--- a/reaper.js
+++ b/reaper.js
@@ -14,7 +14,7 @@ reaper = require('./lib/reaper.js'),
 mailer = require('nodemailer').createTransport('SMTP', { host: 'localhost' }),  // TODO improve
 optimist = require('optimist');
 
-var parser = optimist(args)
+var parser = optimist
   .usage('awsbox reap: reap VMs that have been running for too long')
   .describe('dryrun', 'Perform a dry run')
   .boolean('dryrun')
@@ -30,7 +30,8 @@ vm.listawsboxes(function(err, results) {
   Object.keys(results).forEach(function(instanceName) {
     var i = results[instanceName], 
         instanceId = i.instanceId, 
-        name = (typeof(i.tags['Name']) !== undefined ** i.tags['name'] !== '') ? i.tags['name'] : 'un-named';
+        name = (typeof(i.tags['Name']) !== undefined && i.tags['name'] !== '') ? 
+          i.tags['name'] : 'un-named'
     ;
 
     if (typeof(i.tags['AWSBOX_NOKILL']) != 'undefined') {

--- a/reaper.js
+++ b/reaper.js
@@ -12,6 +12,7 @@ path = require('path'),
 vm = require('./lib/vm.js'),
 reaper = require('./lib/reaper.js'),
 mailer = require('nodemailer').createTransport('SMTP', { host: 'localhost' }),  // TODO improve
+fs = require('fs'),
 optimist = require('optimist');
 
 var parser = optimist
@@ -25,6 +26,13 @@ var parser = optimist
   .default('warn2', 24)
   .describe('terminate', 'num. hours after 2nd warning to terminate the box')
   .default('terminate', 24);
+
+// load email templates
+
+var warning1  = fs.readFileSync(__dirname + '/reaper-templates/warning1.txt');
+console.log(warning1);
+process.exit();
+
 
 vm.listawsboxes(function(err, results) {
   Object.keys(results).forEach(function(instanceName) {


### PR DESCRIPTION
This adds the new CLI tool, `reaper.js` which is meant to be run as a cronjob every hour. Right now it has a fixed schedule of reaping boxes that are 1 week old unless: 
- `AWSBOX_SPAREME` ec2 tag is present. This will add an additional week of life to the AWSBOX. 
- `AWSBOX_NOKILL` ec2 tag is present. These will be always spared from the reaper. Should be used sparingly. 

The reaper will also sending warning messages. The first warning 48 hours before and the final warning 24 hours before. 

Also adds these awsbox commands: 
- `awsbox list-awsboxes` - prints a list of all EC2 instances tagged with `AWSBOX`
- `awsbox spareme <instanceid>` - adds the `AWSBOX_SPAREME` tag to the instance
- `awsbox nokill <instanceid>` - adds the `AWSBOX_NOKILL` tag to the instance
