### PR TITLE
Standardise which environment variables we use

### DIFF
--- a/lib/aws.js
+++ b/lib/aws.js
@@ -5,27 +5,34 @@ NiceRoute53 = require('nice-route53'),
 config = require('./config.js'),
 jsel = require('JSONSelect');
 
-function createEc2Client(region) {
+function createEc2Client(credentials) {
   return new amazonEc2.Ec2({
-    accessKeyId: process.env.AWS_ID,
-    secretAccessKey: process.env.AWS_SECRET,
-    region: region || amazonEc2.US_EAST_1, // default
+    accessKeyId: credentials.accessKeyId,
+    secretAccessKey: credentials.secretAccessKey,
+    region: credentials.region || amazonEc2.US_EAST_1, // default
   });
 }
 
-function createRoute53Client() {
-  return new amazonRoute53.Route53({
-    accessKeyId: process.env.AWS_ID,
-    secretAccessKey: process.env.AWS_SECRET,
-  });
+function createRoute53Client(credentials) {
+  return new amazonRoute53.Route53(credentials);
 }
 
-function createNiceRoute53Client() {
+function createNiceRoute53Client(credentials) {
   return new NiceRoute53({
-    accessKeyId: process.env.AWS_ID,
-    secretAccessKey: process.env.AWS_SECRET,
+    accessKeyId: credentials.accessKeyId,
+    secretAccessKey: credentials.secretAccessKey,
+    region: credentials.region || amazonEc2.US_EAST_1, // default
   });
 }
+
+// Set the default credentials to use since allocateEC2Client() is called in lib/vm.js.
+// Note: We don't set and remember 'region' here.
+var accessKeyId;
+var secretAccessKey;
+exports.setDefaultCredentials = function(credentials) {
+  accessKeyId = credentials.accessKeyId;
+  secretAccessKey = credentials.secretAccessKey;
+};
 
 // make an error from an Amazon error
 exports.makeError = function(err) {
@@ -38,19 +45,21 @@ exports.makeError = function(err) {
 
 // get an aws client instance for the specified region.
 // if region is null, the default will be used.
-exports.createClients = function(region) {
-  region = region || config.region;
+exports.createClients = function(credentials) {
+  credentials.region = credentials.region || config.region;
 
-  // if any of AWS_ID, AWS_SECRET or AWS_REGION is wrong, then these will throw
-  exports.client = createEc2Client(region);
-  exports.route53 = createRoute53Client();
-  exports.niceRoute53 = createNiceRoute53Client();
-
-  return region;
+  // if any of accessKeyId, secretAccressKey or region is wrong, then these will throw
+  exports.client = createEc2Client(credentials);
+  exports.route53 = createRoute53Client(credentials);
+  exports.niceRoute53 = createNiceRoute53Client(credentials);
 };
 
 exports.allocateEC2Client = function(region) {
-  return createEc2Client(region);
+  return createEc2Client({
+    accessKeyId : accessKeyId,
+    secretAccessKey : secretAccessKey,
+    region : region
+  });
 };
 
 exports.zones = function(cb) {
@@ -66,7 +75,12 @@ exports.zones = function(cb) {
         zones: []
       };
 
-      createEc2Client(region.regionName).DescribeAvailabilityZones({
+      var credentials = {
+        accessKeyId : accessKeyId,
+        secretAccessKey : secretAccessKey,
+        region : region.regionName,
+      };
+      createEc2Client(credentials).DescribeAvailabilityZones({
         Filter : [ { Name : "region-name", Value : [ region.regionName ] } ]
       }, function(err, zones) {
         if (complete === -1) return;


### PR DESCRIPTION
The following tools all use AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY,
so let's use them too:
- aws-cli      : https://github.com/aws/aws-cli#getting-started
- aws-sdk-ruby : http://docs.aws.amazon.com/AWSRubySDK/latest/index.html#Basic_Configuration
- aws-sdk-js   : http://docs.aws.amazon.com/AWSJavaScriptSDK/guide/node-configuring.html#Credentials_from_Environment_Variables
