### PR TITLE
write out ver.txt after everything has completed ok

### DIFF
--- a/users/app/post-update.js
+++ b/users/app/post-update.js
@@ -62,7 +62,7 @@ function doDeploy() {
       if (!commands.length) return cb();
       var cmd = commands.shift();
       console.log(">>", cmd[0]);
-      var c = child_process.exec(cmd[1], cmd[2] ? cmd[2] : {}, function(err, se, so) {
+      var c = child_process.exec(cmd[1], cmd[2] ? cmd[2] : {}, function(err, stdout, stderr) {
         checkErr("while " + cmd[0], err);
         runNextCommand(cb);
       });
@@ -215,7 +215,7 @@ function doDeploy() {
     function allDone() {
       console.log('>> extracting current sha');
       var gitver = "git log -1 --oneline master > $HOME/ver.txt";
-      var cp = child_process.exec(gitver, {}, function(err, se, so) {
+      var cp = child_process.exec(gitver, {}, function(err, stdout, stderr) {
         checkErr("while " + gitver, err);
         console.log('>> all done');
       });


### PR DESCRIPTION
Seems to work for me. (I don't believe there's any need to write it out temporarily; it should reflect what is successfully built (not what was attempted)).
