### PR TITLE
update to node 0.10.28

### DIFF
--- a/.cdist/manifest/init
+++ b/.cdist/manifest/init
@@ -16,7 +16,7 @@ require="__update_packages" __package nginx
 require="__update_packages" __package htop
 
 # install node.js
-__nodejs_from_source --node_ver 0.10.25
+__nodejs_from_source --node_ver 0.10.28
 
 # drop a file to let the world know that cdist has been configured
 __file /etc/cdist-configured


### PR DESCRIPTION
update to current latest nodejs 0.10.x (and since persona now requires nodejs >= 0.10.26, this is needed _now_ to get an awsbox built for persona). @chilts r?
